### PR TITLE
FS-64: remove the requesting_user field, will not be needed.

### DIFF
--- a/fileservice/filemaster/models.py
+++ b/fileservice/filemaster/models.py
@@ -306,4 +306,3 @@ class DownloadLog(models.Model):
     archivefile = models.ForeignKey(ArchiveFile, blank=False, null=False, on_delete=models.PROTECT)
     download_requested_on = models.DateTimeField(blank=False, null=False, auto_now_add=True)
     requesting_user = models.ForeignKey(CustomUser, blank=False, null=False, on_delete=models.PROTECT)
-    requesting_email = models.EmailField(blank=True, null=True, help_text='Since the user might be a service account, this field helps track where the original request came from.')


### PR DESCRIPTION
All download requests coming from the UDN will have been from a user's own token via the delegate token process.