### PR TITLE
develop(dependencies): Rolled back Python version to 3.11 due to AWS …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmsdbmitc/dbmisvc:debian12-slim-python3.12-0.6.0 AS builder
+FROM hmsdbmitc/dbmisvc:debian12-slim-python3.11-0.6.0 AS builder
 
 # Install requirements
 RUN apt-get update \
@@ -20,7 +20,7 @@ RUN pip install -U wheel \
     && pip wheel -r /requirements.txt \
         --wheel-dir=/root/wheels
 
-FROM hmsdbmitc/dbmisvc:debian12-slim-python3.12-0.6.0
+FROM hmsdbmitc/dbmisvc:debian12-slim-python3.11-0.6.0
 
 # Copy Python wheels from builder
 COPY --from=builder /root/wheels /root/wheels


### PR DESCRIPTION
…CLIv2 not supporting 3.12